### PR TITLE
Change .into() notation into shorthand of lock instead

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    let mut oodle_path:String = "".to_string();
-    use std::path::Path;
-    if Path::new("C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64").exists() {
-        oodle_path = "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string();
-    } else {
-        oodle_path = "E:/Unreal/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string();
-    };
     winres::WindowsResource::new()
         .set_icon("src/assets/sybil.ico")
         .compile()
@@ -14,7 +7,7 @@ fn main() {
     println!(
         "cargo:rustc-link-search={}",
         std::env::var("OODLE").unwrap_or(
-            oodle_path
+            "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string()
         )
     );
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
 fn main() {
+    let mut oodle_path:String = "".to_string();
+    use std::path::Path;
+    if Path::new("C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64").exists() {
+        oodle_path = "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string();
+    } else {
+        oodle_path = "E:/Unreal/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string();
+    };
     winres::WindowsResource::new()
         .set_icon("src/assets/sybil.ico")
         .compile()
@@ -7,7 +14,7 @@ fn main() {
     println!(
         "cargo:rustc-link-search={}",
         std::env::var("OODLE").unwrap_or(
-            "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string()
+            oodle_path
         )
     );
 }

--- a/src/logic/checks.rs
+++ b/src/logic/checks.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use Ability as A;
 use Location as L;
-use Lock::{Any, All};
+use Lock::{All, Any, Movement as Powerup, Location as Loc};
 pub const CHECKS: [Check; 81] = [
     // dream breaker is randomised with random start
     Check {
@@ -19,16 +19,16 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Health,
         locks: Any(&[
             Any(&[
-                A::Sunsetter.into(),
-                All(&[A::AscendantLight.into(), A::DreamBreaker.into()]),
+                Powerup(A::Sunsetter),
+                All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker)]),
                 // just enough space to do this
-                All(&[A::Slide.into(), A::SolarWind.into()]),
-                A::ClingGem(4).into(),
-                A::SunGreaves.into(),
-                A::HeliacalPower.into(),
+                All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
+                Powerup(A::ClingGem(4)),
+                Powerup(A::SunGreaves),
+                Powerup(A::HeliacalPower),
             ]),
             // you can drop down from the entrance
-            Location::CsMain.into(),
+            Loc(Location::CsMain),
         ]),
     },
     Check {
@@ -37,10 +37,10 @@ pub const CHECKS: [Check; 81] = [
         index: 356,
         drop: Drop::Ability(A::Slide),
         locks: Any(&[
-            A::Slide.into(),
-            A::SunGreaves.into(),
-            All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
-            A::ClingGem(2).into(),
+            Powerup(A::Slide),
+            Powerup(A::SunGreaves),
+            All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
+            Powerup(A::ClingGem(2)),
         ]),
     },
     Check {
@@ -49,8 +49,8 @@ pub const CHECKS: [Check; 81] = [
         index: 357,
         drop: Drop::Ability(A::GoodGraces),
         locks: Any(&[
-            A::ClingGem(6).into(),
-            All(&[A::AscendantLight.into(), A::DreamBreaker.into(), A::SunGreaves.into()]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker), Powerup(A::SunGreaves)]),
         ]),
     },
     Check {
@@ -60,13 +60,13 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::SmallKey,
         locks: Any(&[
             All(&[
-                A::SunGreaves.into(),
+                Powerup(A::SunGreaves),
                 Any(&[
-                    A::Sunsetter.into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()])
+                    Powerup(A::Sunsetter),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)])
                 ]),
             ]),
-            A::ClingGem(4).into(),
+            Powerup(A::ClingGem(4)),
         ]),
     },
     Check {
@@ -74,14 +74,14 @@ pub const CHECKS: [Check; 81] = [
         location: L::StrongEyes,
         index: 215,
         drop: Drop::Health,
-        locks: Any(&[A::SunGreaves.into(), A::ClingGem(4).into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(4))]),
     },
     Check {
         description: "strong eyes' lair",
         location: L::StrongEyes,
         index: 185,
         drop: Drop::SmallKey,
-        locks: Any(&[A::DreamBreaker.into()]),
+        locks: Any(&[Powerup(A::DreamBreaker)]),
     },
     Check {
         description: "the goatling who wants to lick the checkpoint",
@@ -128,11 +128,11 @@ pub const CHECKS: [Check; 81] = [
         index: 444,
         drop: Drop::SmallKey,
         locks: Any(&[
-            A::Sunsetter.into(),
-            A::SunGreaves.into(),
-            A::HeliacalPower.into(),
-            A::ClingGem(2).into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::Sunsetter),
+            Powerup(A::SunGreaves),
+            Powerup(A::HeliacalPower),
+            Powerup(A::ClingGem(2)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -142,7 +142,7 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::Professional),
         locks: All(&[
             Lock::SmallKey,
-            A::DreamBreaker.into()
+            Powerup(A::DreamBreaker)
         ]),
     },
     Check {
@@ -151,8 +151,8 @@ pub const CHECKS: [Check; 81] = [
         index: 495,
         drop: Drop::Health,
         locks: Any(&[
-            A::ClingGem(6).into(),
-            All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
         ]),
     },
     Check {
@@ -161,9 +161,9 @@ pub const CHECKS: [Check; 81] = [
         index: 494,
         drop: Drop::Health,
         locks: Any(&[
-            All(&[A::AscendantLight.into(), A::DreamBreaker.into()]),
-            A::SunGreaves.into(),
-            A::ClingGem(2).into(),
+            All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker)]),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(2)),
         ]),
     },
     Check {
@@ -172,8 +172,8 @@ pub const CHECKS: [Check; 81] = [
         index: 498,
         drop: Drop::Health,
         locks: Any(&[
-            A::ClingGem(6).into(),
-            All(&[A::Slide.into(), A::SolarWind.into(), A::SunGreaves.into(), A::HeliacalPower.into()]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
         ]),
     },
     Check {
@@ -185,8 +185,8 @@ pub const CHECKS: [Check; 81] = [
             "Thought I was gonna have to jump into the haze..."
         ]),
         locks: Any(&[
-            A::ClingGem(6).into(),
-            All(&[A::Slide.into(), A::SolarWind.into(), A::SunGreaves.into(), A::HeliacalPower.into()]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
         ]),
     },
     Check {
@@ -195,8 +195,8 @@ pub const CHECKS: [Check; 81] = [
         index: 790,
         drop: Drop::Ability(A::ClearMind),
         locks: Any(&[
-            A::ClingGem(6).into(),
-            All(&[A::Slide.into(), A::SolarWind.into(), A::SunGreaves.into(), A::HeliacalPower.into()]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
         ]),
     },
     Check {
@@ -204,7 +204,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::CsMain,
         index: 443,
         drop: Drop::SmallKey,
-        locks: Any(&[A::SunGreaves.into(), A::ClingGem(6).into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(6))]),
     },
     Check {
         description: "in the pit next to the dungeon entrance",
@@ -212,9 +212,9 @@ pub const CHECKS: [Check; 81] = [
         index: 497,
         drop: Drop::Health,
         locks: Any(&[
-            A::SunGreaves.into(),
-            A::HeliacalPower.into(),
-            A::ClingGem(6).into(),
+            Powerup(A::SunGreaves),
+            Powerup(A::HeliacalPower),
+            Powerup(A::ClingGem(6)),
         ]),
     },
     Check {
@@ -227,10 +227,10 @@ pub const CHECKS: [Check; 81] = [
             "What? I dont have a problem. You go touch 'em then, bubble girl."
         ]),
         locks: Any(&[
-            A::SunGreaves.into(),
-            A::HeliacalPower.into(),
-            A::ClingGem(4).into(),
-            All(&[A::Slide.into(), A::SunGreaves.into()])
+            Powerup(A::SunGreaves),
+            Powerup(A::HeliacalPower),
+            Powerup(A::ClingGem(4)),
+            All(&[Powerup(A::Slide), Powerup(A::SunGreaves)])
         ]),
     },
     Check {
@@ -239,10 +239,10 @@ pub const CHECKS: [Check; 81] = [
         index: 496,
         drop: Drop::Health,
         locks: Any(&[
-            All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
-            A::ClingGem(4).into(),
-            All(&[A::Slide.into(), A::SolarWind.into(), A::HeliacalPower.into()]),
-            All(&[A::Slide.into(), A::SolarWind.into(), A::SunGreaves.into()]),
+            All(&[Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
+            Powerup(A::ClingGem(4)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::HeliacalPower)]),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::SunGreaves)]),
         ]),
     },
     Check {
@@ -270,21 +270,21 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::Pilgrimage),
         locks: Any(&[
             All(&[
-                A::AscendantLight.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::AscendantLight),
+                Powerup(A::DreamBreaker),
                 Any(&[
-                    A::Sunsetter.into(),
-                    A::SunGreaves.into(),
-                    All(&[A::Slide.into(),A::SolarWind.into()]),
+                    Powerup(A::Sunsetter),
+                    Powerup(A::SunGreaves),
+                    All(&[Powerup(A::Slide),Powerup(A::SolarWind)]),
                 ]),
             ]),
-            All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
+            All(&[Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
             All(&[
-                A::ClingGem(6).into(), 
+                Powerup(A::ClingGem(6)), 
                 Any(&[
-                    A::HeliacalPower.into(),
-                    A::Sunsetter.into(),
-                    All(&[A::Slide.into(),A::SolarWind.into()]),
+                    Powerup(A::HeliacalPower),
+                    Powerup(A::Sunsetter),
+                    All(&[Powerup(A::Slide),Powerup(A::SolarWind)]),
                 ]),
             ]),
         ]),
@@ -294,7 +294,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::CsMain,
         index: 789,
         drop: Drop::Ability(A::GoodGraces),
-        locks: Any(&[A::ClingGem(6).into(), A::SunGreaves.into()]),
+        locks: Any(&[Powerup(A::ClingGem(6)), Powerup(A::SunGreaves)]),
     },
     // Listless Library
     Check {
@@ -310,7 +310,7 @@ pub const CHECKS: [Check; 81] = [
         index: 267,
         drop: Drop::Ability(A::SunGreaves),
         locks: Any(&[
-            A::DreamBreaker.into()
+            Powerup(A::DreamBreaker)
         ]),
     },
     Check {
@@ -326,9 +326,9 @@ pub const CHECKS: [Check; 81] = [
         index: 240,
         drop: Drop::Note,
         locks: Any(&[
-            A::SunGreaves.into(),
-            A::ClingGem(4).into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(4)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -337,9 +337,9 @@ pub const CHECKS: [Check; 81] = [
         index: 242,
         drop: Drop::Chair,
         locks: Any(&[
-            A::SunGreaves.into(),
-            A::ClingGem(4).into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(4)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -347,7 +347,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::MainLibrary,
         index: 213,
         drop: Drop::Health,
-        locks: Any(&[A::SunGreaves.into(), A::ClingGem(4).into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(4))]),
     },
     Check {
         description: "in the hay behind the locked door",
@@ -355,10 +355,10 @@ pub const CHECKS: [Check; 81] = [
         index: 268,
         drop: Drop::Ability(A::ClearMind),
         locks: Any(&[
-            All(&[A::Slide.into(), A::SolarWind.into()]),
-            A::SunGreaves.into(),
-            A::HeliacalPower.into(),
-            A::ClingGem(4).into(),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
+            Powerup(A::SunGreaves),
+            Powerup(A::HeliacalPower),
+            Powerup(A::ClingGem(4)),
         ]),
     },
     Check {
@@ -366,7 +366,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::Restricted,
         index: 214,
         drop: Drop::Health,
-        locks: Any(&[A::SunGreaves.into(), A::ClingGem(4).into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(4))]),
     },
     // Sansa Keep
     Check {
@@ -401,13 +401,13 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::Strikebreak),
         locks: Any(&[
             All(&[
-                A::Strikebreak.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::SoulCutter),
+                Powerup(A::DreamBreaker),
                 Any(&[
-                    A::SunGreaves.into(),
-                    A::HeliacalPower.into(),
-                    A::ClingGem(4).into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::HeliacalPower),
+                    Powerup(A::ClingGem(4)),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             ]),
         ]),
@@ -418,12 +418,12 @@ pub const CHECKS: [Check; 81] = [
         index: 392,
         drop: Drop::Ability(A::Sunsetter),
         locks: All(&[
-            A::DreamBreaker.into(),
+            Powerup(A::DreamBreaker),
             Any(&[
-                A::Sunsetter.into(),
-                A::HeliacalPower.into(),
-                A::SunGreaves.into(),
-                A::ClingGem(2).into()
+                Powerup(A::Sunsetter),
+                Powerup(A::HeliacalPower),
+                Powerup(A::SunGreaves),
+                Powerup(A::ClingGem(2))
             ]),
         ]),
     },
@@ -433,9 +433,9 @@ pub const CHECKS: [Check; 81] = [
         index: 251,
         drop: Drop::Health,
         locks: Any(&[
-            A::Sunsetter.into(),
-            A::SunGreaves.into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::Sunsetter),
+            Powerup(A::SunGreaves),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -443,7 +443,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::SansaKeep,
         index: 226,
         drop: Drop::SmallKey,
-        locks: Any(&[A::DreamBreaker.into()]),
+        locks: Any(&[Powerup(A::DreamBreaker)]),
     },
     Check {
         description: "tucked near the theatre entrance",
@@ -451,10 +451,10 @@ pub const CHECKS: [Check; 81] = [
         index: 394,
         drop: Drop::Ability(A::ClearMind),
         locks: Any(&[
-            A::Sunsetter.into(),
-            A::HeliacalPower.into(),
-            A::SunGreaves.into(),
-            A::ClingGem(4).into(),
+            Powerup(A::Sunsetter),
+            Powerup(A::HeliacalPower),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(4)),
         ]),
     },
     Check {
@@ -464,23 +464,23 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::BigKey,
         locks: Any(&[
             All(&[
-                A::AscendantLight.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::AscendantLight),
+                Powerup(A::DreamBreaker),
                 Any(&[
                     All(&[
-                        A::ClingGem(4).into(),
-                        Any(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+                        Powerup(A::ClingGem(4)),
+                        Any(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
                     ]),
-                    All(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+                    All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
                 ]),
             ]),
             All(&[
-                A::DreamBreaker.into(),
-                A::Slide.into(),
-                A::SolarWind.into(),
-                A::Sunsetter.into(),
-                A::ClingGem(2).into(),
-                A::SunGreaves.into(),
+                Powerup(A::DreamBreaker),
+                Powerup(A::Slide),
+                Powerup(A::SolarWind),
+                Powerup(A::Sunsetter),
+                Powerup(A::ClingGem(2)),
+                Powerup(A::SunGreaves),
             ]),
         ]),
     },
@@ -491,23 +491,23 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Chair,
         locks:  Any(&[
             All(&[
-                A::AscendantLight.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::AscendantLight),
+                Powerup(A::DreamBreaker),
                 Any(&[
                     All(&[
-                        A::ClingGem(4).into(),
-                        Any(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+                        Powerup(A::ClingGem(4)),
+                        Any(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
                     ]),
-                    All(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+                    All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
                 ]),
             ]),
             All(&[
-                A::DreamBreaker.into(),
-                A::Slide.into(),
-                A::SolarWind.into(),
-                A::Sunsetter.into(),
-                A::ClingGem(2).into(),
-                A::SunGreaves.into(),
+                Powerup(A::DreamBreaker),
+                Powerup(A::Slide),
+                Powerup(A::SolarWind),
+                Powerup(A::Sunsetter),
+                Powerup(A::ClingGem(2)),
+                Powerup(A::SunGreaves),
             ]),
         ]),
     },
@@ -517,14 +517,14 @@ pub const CHECKS: [Check; 81] = [
         location: L::EmptyBailey,
         index: 88,
         drop: Drop::Goatling(&["...i'm not here."]),
-        locks: Any(&[A::Slide.into()]),
+        locks: Any(&[Powerup(A::Slide)]),
     },
     Check {
         description: "in the building you slide into",
         location: L::EmptyBailey,
         index: 56,
         drop: Drop::SmallKey,
-        locks: Any(&[A::Slide.into()]),
+        locks: Any(&[Powerup(A::Slide)]),
     },
     Check {
         description: "guarded by the hand and soldier",
@@ -532,10 +532,10 @@ pub const CHECKS: [Check; 81] = [
         index: 55,
         drop: Drop::BigKey,
         locks: Any(&[
-            A::Sunsetter.into(),
-            A::SunGreaves.into(),
-            A::ClingGem(4).into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::Sunsetter),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(4)),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -545,12 +545,12 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::SolarWind),
         locks: Any(&[
             All(&[
-                A::Slide.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::Slide),
+                Powerup(A::DreamBreaker),
                 Any(&[
-                    A::SolarWind.into(),
-                    A::HeliacalPower.into(),
-                    A::SunGreaves.into(),
+                    Powerup(A::SolarWind),
+                    Powerup(A::HeliacalPower),
+                    Powerup(A::SunGreaves),
                 ]),
             ]),
         ]),
@@ -561,10 +561,10 @@ pub const CHECKS: [Check; 81] = [
         index: 66,
         drop: Drop::Health,
         locks: Any(&[
-            All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
-            A::SunGreaves.into(),
+            All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
+            Powerup(A::SunGreaves),
             // you can jump down from cheese bell
-            All(&[A::Slide.into(), A::SolarWind.into(), A::ClingGem(6).into()]),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::ClingGem(6))]),
         ]),
     },
     Check {
@@ -574,15 +574,15 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::Empathy),
         locks: Any(&[
             All(&[
-                A::Slide.into(),
-                A::SolarWind.into(),
+                Powerup(A::Slide),
+                Powerup(A::SolarWind),
                 Any(&[
-                    A::ClingGem(6).into(),
-                    All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
+                    Powerup(A::ClingGem(6)),
+                    All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
                 ]),
             ]),
             
-            All(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+            All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
 
         ]),
     },
@@ -593,8 +593,8 @@ pub const CHECKS: [Check; 81] = [
         index: 515,
         drop: Drop::Health,
         locks: Any(&[
-            A::SunGreaves.into(),
-            All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
+            Powerup(A::SunGreaves),
+            All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
         ]),
     },
     Check {
@@ -604,14 +604,14 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::BigKey,
         locks: Any(&[
             All(&[
-                A::DreamBreaker.into(),
-                A::Sunsetter.into(),
+                Powerup(A::DreamBreaker),
+                Powerup(A::Sunsetter),
                 Any(&[
                     All(&[
-                        A::SoulCutter.into(),
-                        Any(&[A::AscendantLight.into(), A::ClingGem(6).into()]),
+                        Powerup(A::SoulCutter),
+                        Any(&[Powerup(A::AscendantLight), Powerup(A::ClingGem(6))]),
                     ]),
-                    All(&[A::SunGreaves.into(), A::Slide.into(), A::SolarWind.into()]),
+                    All(&[Powerup(A::SunGreaves), Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             ]),
         ]),
@@ -622,14 +622,14 @@ pub const CHECKS: [Check; 81] = [
         index: 834,
         drop: Drop::Ability(A::AscendantLight),
         // you can go through the dark area and there's a passage which you can do with nothing
-        locks: Any(&[A::DreamBreaker.into()]),
+        locks: Any(&[Powerup(A::DreamBreaker)]),
     },
     Check {
         description: "in an alcove behind some pillars",
         location: L::VAscendantLight,
         index: 517,
         drop: Drop::Health,
-        locks: Any(&[A::DreamBreaker.into()]),
+        locks: Any(&[Powerup(A::DreamBreaker)]),
     },
     Check {
         description: "on a missable ledge in the centre",
@@ -637,8 +637,8 @@ pub const CHECKS: [Check; 81] = [
         index: 447,
         drop: Drop::SmallKey,
         locks: Any(&[
-            A::Sunsetter.into(),
-            All(&[A::Slide.into(), A::SolarWind.into()]),
+            Powerup(A::Sunsetter),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
         ]),
     },
     Check {
@@ -648,12 +648,12 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Note,
         locks: Any(&[
             All(&[
-                A::HeliacalPower.into(),
-                A::Sunsetter.into(),
+                Powerup(A::HeliacalPower),
+                Powerup(A::Sunsetter),
                 Any(&[
-                    A::ClingGem(6).into(),
-                    A::SunGreaves.into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    Powerup(A::ClingGem(6)),
+                    Powerup(A::SunGreaves),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             ]),
         ]),
@@ -665,14 +665,14 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::MartialProwess),
         locks: Any(&[
             All(&[
-                A::Strikebreak.into(),
-                A::AscendantLight.into(),
-                A::DreamBreaker.into(),
+                Powerup(A::SoulCutter),
+                Powerup(A::AscendantLight),
+                Powerup(A::DreamBreaker),
                 Any(&[
-                    A::HeliacalPower.into(),
-                    A::SunGreaves.into(),
-                    A::Sunsetter.into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    Powerup(A::HeliacalPower),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::Sunsetter),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             ]),
         ]),
@@ -684,7 +684,7 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::HeliacalPower),
         locks: All(&[
             Lock::SmallKey,
-            A::DreamBreaker.into(),
+            Powerup(A::DreamBreaker),
         ]),
     },
     Check {
@@ -694,7 +694,7 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Note,
         locks: All(&[
             Lock::SmallKey,
-            A::DreamBreaker.into(),
+            Powerup(A::DreamBreaker),
         ]),
     },
     Check {
@@ -703,11 +703,11 @@ pub const CHECKS: [Check; 81] = [
         index: 704,
         drop: Drop::Note,
         locks: Any(&[
-            A::SunGreaves.into(),
-            All(&[A::HeliacalPower.into(), A::Sunsetter.into()]),
-            A::ClingGem(6).into(),
-            All(&[A::AscendantLight.into(), A::DreamBreaker.into()]),
-            All(&[A::Slide.into(), A::SolarWind.into()])
+            Powerup(A::SunGreaves),
+            All(&[Powerup(A::HeliacalPower), Powerup(A::Sunsetter)]),
+            Powerup(A::ClingGem(6)),
+            All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker)]),
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind)])
         ]),
     },
     Check {
@@ -715,7 +715,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::BaileyHole,
         index: 516,
         drop: Drop::Health,
-        locks: Any(&[A::SunGreaves.into(), A::Sunsetter.into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::Sunsetter)]),
     },
     // Tower Ruins
     Check {
@@ -724,9 +724,9 @@ pub const CHECKS: [Check; 81] = [
         index: 89,
         drop: Drop::Ability(A::ClingGem(6)),
         locks: Any(&[
-            A::ClingGem(6).into(),
-            A::SunGreaves.into(),
-            All(&[A::HeliacalPower.into(), A::Sunsetter.into()]),
+            Powerup(A::ClingGem(6)),
+            Powerup(A::SunGreaves),
+            All(&[Powerup(A::HeliacalPower), Powerup(A::Sunsetter)]),
         ]),
     },
     Check {
@@ -736,12 +736,12 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::BigKey,
         locks: Any(&[
             All(&[
-                A::ClingGem(2).into(),
+                Powerup(A::ClingGem(2)),
                 Any(&[
-                    A::SunGreaves.into(),
+                    Powerup(A::SunGreaves),
                     All(&[
-                        A::HeliacalPower.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::Sunsetter),
                     ]),
                 ]),
             ]),
@@ -755,11 +755,11 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::AerialFinesse),
         locks: Any(&[
             All(&[
-                Any(&[A::SunGreaves.into(), A::ClingGem(2).into()]),
-                Any(&[A::Slide.into(), A::SolarWind.into()]),
+                Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(2))]),
+                Any(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
             ]),
-            All(&[A::ClingGem(2).into(), A::SunGreaves.into()]),
-            All(&[A::Sunsetter.into(), A::SunGreaves.into()]),
+            All(&[Powerup(A::ClingGem(2)), Powerup(A::SunGreaves)]),
+            All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
         ]),
     },
     Check {
@@ -846,9 +846,9 @@ pub const CHECKS: [Check; 81] = [
             "i will [#cf2525](kill again)"
         ]),
         locks: Any(&[
-            All(&[A::Slide.into(), A::SolarWind.into(), A::HeliacalPower.into()]),
-            A::SunGreaves.into(),
-            A::ClingGem(6).into()
+            All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::HeliacalPower)]),
+            Powerup(A::SunGreaves),
+            Powerup(A::ClingGem(6))
         ]),
     },
     Check {
@@ -857,8 +857,8 @@ pub const CHECKS: [Check; 81] = [
         index: 947,
         drop: Drop::Chair,
         locks: Any(&[
-                A::ClingGem(4).into(),
-                All(&[A::Slide.into(), A::SolarWind.into(), A::HeliacalPower.into(), A::SunGreaves.into()]),
+                Powerup(A::ClingGem(4)),
+                All(&[Powerup(A::Slide), Powerup(A::SolarWind), Powerup(A::HeliacalPower), Powerup(A::SunGreaves)]),
             ]),
     },
     Check {
@@ -868,10 +868,10 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Chair,
         locks: Any(&[
             All(&[
-                A::Strikebreak.into(),
-                A::SoulCutter.into(),
-                A::DreamBreaker.into(),
-                Any(&[A::SunGreaves.into(), A::ClingGem(4).into()]),
+                Powerup(A::SoulCutter),
+                Powerup(A::SoulCutter),
+                Powerup(A::DreamBreaker),
+                Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(4))]),
             ]),
         ]),
     },
@@ -882,14 +882,14 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::BigKey,
         // there's one gap in the open green room with enemies which is too big
         locks: All(&[
-            A::DreamBreaker.into(),
-            A::Strikebreak.into(), 
-            A::SoulCutter.into(), 
-            A::ClingGem(6).into(),
+            Powerup(A::DreamBreaker),
+            Powerup(A::SoulCutter), 
+            Powerup(A::SoulCutter), 
+            Powerup(A::ClingGem(6)),
             Any(&[
-                A::HeliacalPower.into(),
-                A::SunGreaves.into(),
-                All(&[A::Slide.into(), A::SolarWind.into()])
+                Powerup(A::HeliacalPower),
+                Powerup(A::SunGreaves),
+                All(&[Powerup(A::Slide), Powerup(A::SolarWind)])
             ]),
         ]),
     },
@@ -899,12 +899,12 @@ pub const CHECKS: [Check; 81] = [
         index: 1079,
         drop: Drop::Ability(A::SoulCutter),
         locks: All(&[
-            A::DreamBreaker.into(),
-            A::Strikebreak.into(), 
-            A::SoulCutter.into(),
+            Powerup(A::DreamBreaker),
+            Powerup(A::SoulCutter), 
+            Powerup(A::SoulCutter),
             Any(&[
-                A::ClingGem(6).into(),
-                A::SunGreaves.into(),
+                Powerup(A::ClingGem(6)),
+                Powerup(A::SunGreaves),
             ]),
         ]),
     },
@@ -913,7 +913,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::MainTheatre,
         index: 844,
         drop: Drop::Health,
-        locks: Any(&[A::SunGreaves.into(), A::ClingGem(6).into()]),
+        locks: Any(&[Powerup(A::SunGreaves), Powerup(A::ClingGem(6))]),
     },
     Check {
         description: "behind the locked door",
@@ -922,10 +922,10 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Ability(A::Empathy),
         locks: All(&[
             Lock::SmallKey,
-            A::DreamBreaker.into(),
+            Powerup(A::DreamBreaker),
             Any(&[
-                A::SunGreaves.into(),
-                A::ClingGem(2).into(),
+                Powerup(A::SunGreaves),
+                Powerup(A::ClingGem(2)),
             ]),
         ]),
     },

--- a/src/logic/checks.rs
+++ b/src/logic/checks.rs
@@ -10,7 +10,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::VDreamBreaker,
         index: 355,
         drop: Drop::Ability(A::DreamBreaker),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "where the first health piece is",
@@ -92,35 +92,35 @@ pub const CHECKS: [Check; 81] = [
             "They make me feel safe...",
             "I think i'm gonna lick it. I bet it's full of [#8ada1c, buoy, italics](minerals).",
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "a chair next to the goatling who wants to lick the checkpoint",
         location: L::CsMain,
         index: 634,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "a chair next to the goatling who wants to lick the checkpoint",
         location: L::CsMain,
         index: 635,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "a chair next to the goatling who wants to lick the checkpoint",
         location: L::CsMain,
         index: 636,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "where indignation normally is",
         location: L::CsMain,
         index: 787,
         drop: Drop::Ability(A::Indignation),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "chillin' on a ledge by the window",
@@ -254,14 +254,14 @@ pub const CHECKS: [Check; 81] = [
             "But the handmaiden has run out of her special ingredient.",
             "I guess the princess doesn't really want anybody else's tea...",
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the chair in the gazebo",
         location: L::CsMain,
         index: 637,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "next to a bouncer in the massive room",
@@ -302,7 +302,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::MainLibrary,
         index: 241,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "where sun greaves normally are",
@@ -318,7 +318,7 @@ pub const CHECKS: [Check; 81] = [
         location: L::LibSaveNearGreaves,
         index: 243,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the note next to the egg nest",
@@ -376,7 +376,7 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Goatling(&[
             "They took away all my furniture."
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling collapsing out of reality",
@@ -385,14 +385,14 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Goatling(&[
             "[6rr](.....c.....y..u...i....y.......ce....)"
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the chair collapsing out of reality",
         location: L::SkCastleRampEntry,
         index: 325,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "where strikebreak normally is",
@@ -767,28 +767,28 @@ pub const CHECKS: [Check; 81] = [
         location: L::OtherTheatrePath,
         index: 949,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "a chair around the table",
         location: L::OtherTheatrePath,
         index: 950,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "a chair around the table",
         location: L::OtherTheatrePath,
         index: 946,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the chair next to the books",
         location: L::OtherTheatrePath,
         index: 951,
         drop: Drop::Chair,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling who can eat 20 beans at least",
@@ -799,7 +799,7 @@ pub const CHECKS: [Check; 81] = [
             "three bean casserole? not enough for 1 man. i can eat like, [#cf2525](20 beans), at least.",
             "so get to it. [up, 10rr](please?)"
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling who thought the theatre was safe",
@@ -809,7 +809,7 @@ pub const CHECKS: [Check; 81] = [
             "I heard that the theatre was still in good condition...",
             "But it seems even this place has been affected."
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling who really wanted to see the show",
@@ -818,7 +818,7 @@ pub const CHECKS: [Check; 81] = [
         drop: Drop::Goatling(&[
             "Ah nuts....I really wanted to see the show today."
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling who really wanted to see the show",
@@ -828,14 +828,14 @@ pub const CHECKS: [Check; 81] = [
             "Sorry miss, can't let you in.",
             "Theatre's closed until all the haze is gone."
         ]),
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "hiding amid the boxes",
         location: L::MainTheatre,
         index: 843,
         drop: Drop::Health,
-        locks: Any(&[]),
+        locks: Lock::None,
     },
     Check {
         description: "the goatling that will kill again",

--- a/src/logic/locations.rs
+++ b/src/logic/locations.rs
@@ -65,7 +65,7 @@ pub enum Location {
 
 use Ability as A;
 use Location as L;
-use Lock::{All, Any};
+use Lock::{All, Any, Movement as Powerup, Location as Loc};
 impl Location {
     // need to include some reverse directions
     pub const fn locks(&self) -> Lock {
@@ -73,74 +73,74 @@ impl Location {
             // Prison / Dilapidated Dungeon
             L::LatePrison => All(&[
                 Any(&[
-                    A::DreamBreaker.into(),
-                    L::CsMain.into(),
+                    Powerup(A::DreamBreaker),
+                    Loc(L::CsMain),
                 ]),
 
                 Any(&[
-                    L::PEntryUnderBelly.into(),
-                    L::EarlyPrison.into()
+                    Loc(L::PEntryUnderBelly),
+                    Loc(L::EarlyPrison)
                 ]),
             ]),
             L::EarlyPrison => All(&[
                 Any(&[
-                    A::DreamBreaker.into(),
-                    L::CsMain.into(),
+                    Powerup(A::DreamBreaker),
+                    Loc(L::CsMain),
                 ]),
                 Any(&[
                     All(&[
-                        L::StrongEyes.into(),
+                        Loc(L::StrongEyes),
                         Lock::SmallKey
                     ]),
-                    L::VDreamBreaker.into(),
-                    L::LatePrison.into()
+                    Loc(L::VDreamBreaker),
+                    Loc(L::LatePrison)
                 ]),
             ]),
             L::PEntryUnderBelly => All(&[
-                A::DreamBreaker.into(),
+                Powerup(A::DreamBreaker),
                 Any(&[
-                    L::LatePrison.into(),
+                    Loc(L::LatePrison),
                     All(&[
-                        L::PrisonHole.into(),
-                        A::AscendantLight.into(),
+                        Loc(L::PrisonHole),
+                        Powerup(A::AscendantLight),
                     ]),
                 ]),
             ]),
             L::VDreamBreaker => All(&[
-                L::EarlyPrison.into()
+                Loc(L::EarlyPrison)
             ]),
             L::StrongEyes => All(&[
                 Any(&[
                     All(&[
-                        L::LatePrison.into(),
-                        A::Slide.into()
+                        Loc(L::LatePrison),
+                        Powerup(A::Slide)
                     ]),
                     All(&[
-                        L::CsMain.into(),
+                        Loc(L::CsMain),
                         Lock::SmallKey,
-                        A::DreamBreaker.into(),
+                        Powerup(A::DreamBreaker),
                     ]),
                 ]),
             ]),
             L::PEntryCastle => All(&[
                 Any(&[
-                    L::CsPrisonEntry.into(),
+                    Loc(L::CsPrisonEntry),
                     All(&[
-                        L::StrongEyes.into(),
+                        Loc(L::StrongEyes),
                         Lock::SmallKey,
-                        A::DreamBreaker.into()
+                        Powerup(A::DreamBreaker)
                     ]),
                 ]),
             ]),
             L::PEntryTheatre => All(&[
                 Any(&[
-                    L::ThDungeonEntry.into(),
+                    Loc(L::ThDungeonEntry),
                     All(&[
-                        L::LatePrison.into(),
+                        Loc(L::LatePrison),
                         Any(&[
-                            A::ClingGem(6).into(),
-                            A::SunGreaves.into(),
-                            A::AscendantLight.into(),
+                            Powerup(A::ClingGem(6)),
+                            Powerup(A::SunGreaves),
+                            Powerup(A::AscendantLight),
                         ]),
                     ]),
                 ]),
@@ -148,31 +148,31 @@ impl Location {
             // Castle Sansa
             L::CsPrisonEntry => All(&[
                 Any(&[
-                    L::CsMain.into(),
-                    L::PEntryCastle.into(),
+                    Loc(L::CsMain),
+                    Loc(L::PEntryCastle),
                 ]),
             ]),
             L::CsLibraryEntry => All(&[
                 Any(&[
-                    L::MainLibrary.into(),
+                    Loc(L::MainLibrary),
                     All(&[
-                        L::CsMain.into(),
-                        A::DreamBreaker.into(),
+                        Loc(L::CsMain),
+                        Powerup(A::DreamBreaker),
                     ]),
                 ]),
             ]),
             L::CsTheatreEntryNearPrison => All(&[
                 Any(&[
-                    L::PillarRoom.into(),
+                    Loc(L::PillarRoom),
                     All(&[
-                        L::CsMain.into(),
+                        Loc(L::CsMain),
                         Any(&[
-                            A::SunGreaves.into(),
-                            A::Sunsetter.into(),
-                            A::ClingGem(4).into(),
+                            Powerup(A::SunGreaves),
+                            Powerup(A::Sunsetter),
+                            Powerup(A::ClingGem(4)),
                             All(&[
-                                A::Slide.into(),
-                                A::SolarWind.into(),
+                                Powerup(A::Slide),
+                                Powerup(A::SolarWind),
                             ]),
                         ]),
                     ]),
@@ -182,59 +182,59 @@ impl Location {
                 
                 Any(&[
                     All(&[
-                        L::CsMain.into(),
-                        A::ClingGem(2).into(),
+                        Loc(L::CsMain),
+                        Powerup(A::ClingGem(2)),
                     ]),
                     All(&[
-                        L::CsTheatreEntrance.into(),
-                        A::Slide.into(),
+                        Loc(L::CsTheatreEntrance),
+                        Powerup(A::Slide),
                         Any(&[
-                            A::HeliacalPower.into(),
-                            A::SunGreaves.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::HeliacalPower),
+                            Powerup(A::SunGreaves),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
             ]),
             L::CsKeepClimbEntrance => All(&[
-                L::CsMain.into(),
+                Loc(L::CsMain),
                 Lock::SmallKey,
             ]),
             L::CsKeepEntryMain => Any(&[
-                L::CsMain.into(),
-                L::SansaKeep.into(),
+                Loc(L::CsMain),
+                Loc(L::SansaKeep),
             ]),
             L::CsKeepEntryRamp => Any(&[
                 All(&[
-                    L::CsMain.into(),
+                    Loc(L::CsMain),
                     Any(&[
-                        A::DreamBreaker.into(),
-                        A::ClingGem(4).into(),
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::DreamBreaker),
+                        Powerup(A::ClingGem(4)),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
                     ]),
                 ]),
-                L::SansaKeep.into(),
+                Loc(L::SansaKeep),
             ]),
             L::CsBaileyEntry => Any(&[
-                L::CsMain.into(),
-                L::EbEntryCastle.into(),
+                Loc(L::CsMain),
+                Loc(L::EbEntryCastle),
             ]),
             L::CsMain => All(&[
                 Any(&[
-                    L::CsPrisonEntry.into(),
-                    L::CsBaileyEntry.into(),
-                    L::CsTheatreEntryNearPrison.into(),
+                    Loc(L::CsPrisonEntry),
+                    Loc(L::CsBaileyEntry),
+                    Loc(L::CsTheatreEntryNearPrison),
                     All(&[
-                        L::CsOldSoftlockRoom.into(),
-                        A::ClingGem(4).into()
+                        Loc(L::CsOldSoftlockRoom),
+                        Powerup(A::ClingGem(4))
                     ]),
                     All(&[
-                        A::DreamBreaker.into(),
+                        Powerup(A::DreamBreaker),
                         Any(&[
-                            L::CsLibraryEntry.into(),
+                            Loc(L::CsLibraryEntry),
                             All(&[
-                                L::CsKeepClimbEntrance.into(),
+                                Loc(L::CsKeepClimbEntrance),
                                 Lock::SmallKey,
                             ]),
                         ]),
@@ -242,219 +242,219 @@ impl Location {
                 ]),
             ]),
             L::CsTheatreEntrance => Any(&[
-                L::ThCastleEntryMain.into(),
+                Loc(L::ThCastleEntryMain),
                 All(&[
-                    L::CsOldSoftlockRoom.into(),
-                    A::Sunsetter.into(),
-                    A::ClingGem(4).into(),
+                    Loc(L::CsOldSoftlockRoom),
+                    Powerup(A::Sunsetter),
+                    Powerup(A::ClingGem(4)),
                     Any(&[
-                        A::HeliacalPower.into(),
-                        A::SunGreaves.into(),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::SunGreaves),
                     ]),
                 ]),
             ]),
             // Library
             L::LibSaveNearGreaves => All(&[
-                L::MainLibrary.into(), // Can only reach here from main library OR random spawn
+                Loc(L::MainLibrary), // Can only reach here from main library OR random spawn
                 // Enter from the front entrance through the slide slot.
                 All(&[
-                    A::DreamBreaker.into(),
-                    A::Slide.into(),
+                    Powerup(A::DreamBreaker),
+                    Powerup(A::Slide),
                     Any(&[
-                        A::SolarWind.into(),
-                        A::Sunsetter.into(),
-                        A::SunGreaves.into(),
+                        Powerup(A::SolarWind),
+                        Powerup(A::Sunsetter),
+                        Powerup(A::SunGreaves),
                     ]), 
                 ]),
                 //Enter through Reverse route.
                 Any(&[
-                    A::SunGreaves.into(), // Add trick MOVEMENT here once implemented, level Advanced.
+                    Powerup(A::SunGreaves), // Add trick MOVEMENT here once implemented, level Advanced.
                     All(&[
-                        A::ClingGem(2).into(),
+                        Powerup(A::ClingGem(2)),
                         Any(&[
-                            A::Sunsetter.into(),
-                            A::HeliacalPower.into(),
+                            Powerup(A::Sunsetter),
+                            Powerup(A::HeliacalPower),
                         ])
                     ]), // Add Movement trick here level Expert
                     All(&[
-                        A::Slide.into(),
-                        A::SolarWind.into(),
-                        A::HeliacalPower.into()
+                        Powerup(A::Slide),
+                        Powerup(A::SolarWind),
+                        Powerup(A::HeliacalPower)
                     ]), // Add Movement trick here level Advanced
                 ]),
             ]),
             L::MainLibrary => Any(&[
                 All(&[
-                    L::CsMain.into(),
-                    A::DreamBreaker.into(),
+                    Loc(L::CsMain),
+                    Powerup(A::DreamBreaker),
                 ]),
                 All(&[
-                    L::LibSaveNearGreaves.into(),
+                    Loc(L::LibSaveNearGreaves),
                     Any(&[
-                        A::SunGreaves.into(),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::HeliacalPower.into(),
+                            Powerup(A::HeliacalPower),
                             Any(&[
-                                A::ClingGem(2).into(),
-                                A::DreamBreaker.into(),
+                                Powerup(A::ClingGem(2)),
+                                Powerup(A::DreamBreaker),
                                 All(&[
-                                    A::Slide.into(),
-                                    A::SolarWind.into(),
+                                    Powerup(A::Slide),
+                                    Powerup(A::SolarWind),
                                 ]),
                             ]),
                         ]),
                         All(&[
-                            A::ClingGem(2).into(),
-                            A::Sunsetter.into(),
+                            Powerup(A::ClingGem(2)),
+                            Powerup(A::Sunsetter),
                         ]),
                     ]),
                 ]),
             ]),
             L::Restricted => All(&[
-                L::MainLibrary.into(),
+                Loc(L::MainLibrary),
                 Lock::SmallKey,
-                A::DreamBreaker.into(),
+                Powerup(A::DreamBreaker),
             ]),
             // Sansa Keep
             L::SkCastleClimbEntry => All(&[
-                L::CsKeepClimbEntrance.into(),
+                Loc(L::CsKeepClimbEntrance),
             ]),
             L::SkCastleMainEntry => Any(&[
-                L::SansaKeep.into(),
-                L::CsKeepEntryMain.into(),
+                Loc(L::SansaKeep),
+                Loc(L::CsKeepEntryMain),
             ]),
             L::SkCastleRampEntry => Any(&[
                 All(&[
-                    L::SansaKeep.into(),
+                    Loc(L::SansaKeep),
                     Any(&[
-                        A::ClingGem(2).into(),
-                        A::SunGreaves.into(),
+                        Powerup(A::ClingGem(2)),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
-                L::CsKeepEntryRamp.into(),
+                Loc(L::CsKeepEntryRamp),
             ]),
             L::SkUnderbellyEntry => Any(&[
                 All(&[
-                    L::SansaKeep.into(),
+                    Loc(L::SansaKeep),
                     Any(&[
-                        A::Sunsetter.into(),
-                        A::HeliacalPower.into(),
-                        A::SunGreaves.into(),
+                        Powerup(A::Sunsetter),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
-                L::SansaHole.into(),
+                Loc(L::SansaHole),
             ]),
             L::SkTheatreEntry => Any(&[
-                L::ThKeepEntry.into(),
+                Loc(L::ThKeepEntry),
                 All(&[
-                    L::SansaKeep.into(),
+                    Loc(L::SansaKeep),
                     Any(&[
-                        A::SunGreaves.into(),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
             ]),
             L::SansaKeep => Any(&[
-                L::SkCastleRampEntry.into(),
-                L::SkCastleMainEntry.into(),
+                Loc(L::SkCastleRampEntry),
+                Loc(L::SkCastleMainEntry),
                 All(&[
-                    L::MainTheatre.into(),
-                    A::ClingGem(2).into(),
+                    Loc(L::MainTheatre),
+                    Powerup(A::ClingGem(2)),
                 ]),
                 All(&[
-                    L::SkUnderbellyEntry.into(),
+                    Loc(L::SkUnderbellyEntry),
                     Any(&[
-                        A::Sunsetter.into(),
-                        A::HeliacalPower.into(),
-                        A::SunGreaves.into(),
+                        Powerup(A::Sunsetter),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                         // Add just MOVMENT trick Normal here since can just backflip up each of em lol.
                     ])
                 ]),
             ]),
             L::Sunsetter => All(&[
-                L::SansaKeep.into(),
+                Loc(L::SansaKeep),
                 Any(&[
                     All(&[
                         Lock::SmallKey,
-                        A::DreamBreaker.into()
+                        Powerup(A::DreamBreaker)
                     ]),
-                    A::SunGreaves.into(),
-                    A::ClingGem(2).into(),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::ClingGem(2)),
                 ]),
             ]),
             // Bailey
             L::EbEntryCastle => Any(&[
-                L::CsBaileyEntry.into(),
-                L::EmptyBailey.into(),
+                Loc(L::CsBaileyEntry),
+                Loc(L::EmptyBailey),
             ]),
             L::EbEntryRuins => All(&[
                 Any(&[
-                    L::TowerRuinsEntrance.into(),
-                    L::EmptyBailey.into(),
+                    Loc(L::TowerRuinsEntrance),
+                    Loc(L::EmptyBailey),
                 ]),
                 Any(&[
-                    A::SunGreaves.into(),
-                    A::Sunsetter.into(),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::Sunsetter),
                     All(&[
-                        A::ClingGem(2).into(),
-                        A::HeliacalPower.into(),
+                        Powerup(A::ClingGem(2)),
+                        Powerup(A::HeliacalPower),
                     ]),
                     All(&[
-                        A::Slide.into(),
-                        A::SolarWind.into(),
+                        Powerup(A::Slide),
+                        Powerup(A::SolarWind),
                     ]),
                 ]),
             ]),
             L::EbEntryTheatre => Any(&[
-                L::EmptyBailey.into(),
-                L::PillarRoom.into(),
+                Loc(L::EmptyBailey),
+                Loc(L::PillarRoom),
             ]),
             L::EbEntryUnderBelly => Any(&[
-                L::BaileyHole.into(),
+                Loc(L::BaileyHole),
                 All(&[
-                    L::EmptyBailey.into(),
+                    Loc(L::EmptyBailey),
                     Any(&[
-                        A::Sunsetter.into(),
-                        A::SunGreaves.into(),
-                        A::HeliacalPower.into(),
+                        Powerup(A::Sunsetter),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::HeliacalPower),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
             ]),
             L::EmptyBailey => Any(&[
-                L::EbEntryCastle.into(),
-                L::EbEntryUnderBelly.into(),
-                L::EbEntryTheatre.into(),
+                Loc(L::EbEntryCastle),
+                Loc(L::EbEntryUnderBelly),
+                Loc(L::EbEntryTheatre),
                 All(&[
-                    L::EbEntryRuins.into(),
+                    Loc(L::EbEntryRuins),
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
                         All(&[
-                            A::ClingGem(2).into(),
-                            A::HeliacalPower.into(),
+                            Powerup(A::ClingGem(2)),
+                            Powerup(A::HeliacalPower),
                         ]),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
@@ -462,286 +462,286 @@ impl Location {
             // Tower
             L::TowerRuinsEntrance => Any(&[
                 All(&[
-                    L::EmptyBailey.into(),
+                    Loc(L::EmptyBailey),
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
                         All(&[
-                            A::ClingGem(2).into(),
-                            A::HeliacalPower.into(),
+                            Powerup(A::ClingGem(2)),
+                            Powerup(A::HeliacalPower),
                         ]),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
                         ]),
                     ]),
                 ]),
-                L::TowerRuinsKeep.into(),
+                Loc(L::TowerRuinsKeep),
             ]),
             L::TowerRuinsKeep => Any(&[
                 All(&[
-                    L::TowerRuinsEntrance.into(),
+                    Loc(L::TowerRuinsEntrance),
                     Any(&[
                         //ADD MOVEMENT TRICK AND CLING ABUSE HERE. EXPERT / ADVANCED 
-                        A::SunGreaves.into(),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::ClingGem(2).into(),
+                            Powerup(A::ClingGem(2)),
                             Any(&[
-                                A::Sunsetter.into(),
-                                A::HeliacalPower.into(),
+                                Powerup(A::Sunsetter),
+                                Powerup(A::HeliacalPower),
                             ]),
                         ]),
                     ]),
                 ]),
-                L::FinalBoss.into()
+                Loc(L::FinalBoss)
             ]),
             // Underbelly
             L::PrisonHole => Any(&[
                 All(&[
-                    L::PEntryUnderBelly.into(),
-                    A::DreamBreaker.into(),
+                    Loc(L::PEntryUnderBelly),
+                    Powerup(A::DreamBreaker),
                 ]),
                 All(&[
-                    L::MainUnderbelly.into(), // From main to the hole (right below the gear mobs.)
+                    Loc(L::MainUnderbelly), // From main to the hole (right below the gear mobs.)
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into()
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind)
                         ]),
                     ]),
                 ]),
             ]),
             L::BaileyHole => Any(&[
                 All(&[
-                    A::Sunsetter.into(),
+                    Powerup(A::Sunsetter),
                     Any(&[
-                        L::EbEntryUnderBelly.into(),
-                        L::SansaHole.into(),
+                        Loc(L::EbEntryUnderBelly),
+                        Loc(L::SansaHole),
                     ]),
                 ]),
-                L::MainUnderbelly.into(), // From main to hole.
+                Loc(L::MainUnderbelly), // From main to hole.
             ]),
             L::SansaHole => Any(&[
                 All(&[
-                    A::Sunsetter.into(),
+                    Powerup(A::Sunsetter),
                     Any(&[
-                        L::MainUnderbelly.into(),
-                        L::BaileyHole.into(),
+                        Loc(L::MainUnderbelly),
+                        Loc(L::BaileyHole),
                         All(&[
-                            L::HpSave.into(),
-                            A::Slide.into(),
+                            Loc(L::HpSave),
+                            Powerup(A::Slide),
                         ]),
                     ]),
                 ]),
                 All(&[
-                    L::SkUnderbellyEntry.into(),
+                    Loc(L::SkUnderbellyEntry),
                     Any(&[
-                        A::HeliacalPower.into(),
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
                     ]),
                 ]),
             ]),
             L::MainUnderbelly => Any(&[
-                L::PrisonHole.into(),
+                Loc(L::PrisonHole),
                 All(&[
-                    L::BaileyHole.into(),
-                    A::SunGreaves.into(),
-                    A::HeliacalPower.into(), 
-                    A::Sunsetter.into(),
+                    Loc(L::BaileyHole),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::HeliacalPower), 
+                    Powerup(A::Sunsetter),
                 ]), // First bubble directly to circular platforms.
                 All(&[
-                    L::HpSave.into(),
+                    Loc(L::HpSave),
                     Any(&[
-                        A::DreamBreaker.into(),
+                        Powerup(A::DreamBreaker),
                         // Below is sliding through the gap above the hanging block and then doing an ultra to skip the lever.
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
-                            A::SunGreaves.into(),
-                            A::ClingGem(2).into()
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
+                            Powerup(A::SunGreaves),
+                            Powerup(A::ClingGem(2))
                         ]),
                     ]),
                 ]),
                 All(&[
-                    L::SansaHole.into(),
-                    A::Sunsetter.into(), 
-                    A::Slide.into(),
+                    Loc(L::SansaHole),
+                    Powerup(A::Sunsetter), 
+                    Powerup(A::Slide),
                 ]), // from Sansa hole (above going to Major Key)
             ]),
             L::VAscendantLight => All(&[
-                L::PrisonHole.into(),
-                A::DreamBreaker.into(),
+                Loc(L::PrisonHole),
+                Powerup(A::DreamBreaker),
             ]),
             L::HpSave => Any(&[
                 All(&[
-                    L::BaileyHole.into(),
-                    A::Slide.into(),
+                    Loc(L::BaileyHole),
+                    Powerup(A::Slide),
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::Sunsetter.into(),
-                        A::HeliacalPower.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::Sunsetter),
+                        Powerup(A::HeliacalPower),
                     ]),
                 ]),
                 All(&[
-                    L::MainUnderbelly.into(),
-                    A::DreamBreaker.into(),
+                    Loc(L::MainUnderbelly),
+                    Powerup(A::DreamBreaker),
                     Any(&[
                         All(&[
-                            A::HeliacalPower.into(),
+                            Powerup(A::HeliacalPower),
                             Any(&[
-                                A::SunGreaves.into(),
+                                Powerup(A::SunGreaves),
                                 All(&[
-                                    A::Slide.into(),
-                                    A::SolarWind.into(),
+                                    Powerup(A::Slide),
+                                    Powerup(A::SolarWind),
                                 ]),
                             ]),
                         ]),
                         All(&[
-                            A::ClingGem(2).into(),
-                            A::Sunsetter.into(),
+                            Powerup(A::ClingGem(2)),
+                            Powerup(A::Sunsetter),
                         ])
                     ]),
                 ]),
             ]),
             //Theatre
             L::ThBaileyEntry => Any(&[
-                L::EbEntryTheatre.into(),
+                Loc(L::EbEntryTheatre),
                 All(&[
-                    L::PillarRoom.into(), 
+                    Loc(L::PillarRoom), 
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::HeliacalPower.into(),
-                        A::ClingGem(2).into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::ClingGem(2)),
+                        Powerup(A::Sunsetter),
                     ]),
                 ]),
             ]),
             L::ThCastleEntryMain => Any(&[
-                L::CsTheatreEntrance.into(),
-                L::TheatreEntrance.into(),
+                Loc(L::CsTheatreEntrance),
+                Loc(L::TheatreEntrance),
             ]),
             L::ThCastleEntryPillar => Any(&[
-                L::CsTheatreEntryNearPrison.into(),
+                Loc(L::CsTheatreEntryNearPrison),
                 All(&[
-                    L::PillarRoom.into(), 
+                    Loc(L::PillarRoom), 
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::HeliacalPower.into(),
-                        A::ClingGem(2).into(),
-                        A::Sunsetter.into(),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::ClingGem(2)),
+                        Powerup(A::Sunsetter),
                     ]),
                 ]),
             ]),
             L::ThKeepEntry => Any(&[
-                L::SkTheatreEntry.into(),
+                Loc(L::SkTheatreEntry),
                 All(&[
-                    L::OtherTheatrePath.into(), 
+                    Loc(L::OtherTheatrePath), 
                     Any(&[
-                        All(&[A::AscendantLight.into(), A::DreamBreaker.into()]), 
-                        A::HeliacalPower.into(),
-                        A::ClingGem(2).into(),
+                        All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker)]), 
+                        Powerup(A::HeliacalPower),
+                        Powerup(A::ClingGem(2)),
                     ]),
                 ]),
             ]),
             L::ThDungeonEntry => Any(&[
                 All(&[
-                    L::OtherTheatrePath.into(),
+                    Loc(L::OtherTheatrePath),
                     Any(&[
-                        All(&[A::AscendantLight.into(), A::DreamBreaker.into()]),
-                        All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
-                        A::SunGreaves.into(),
-                        A::ClingGem(2).into(),
+                        All(&[Powerup(A::AscendantLight), Powerup(A::DreamBreaker)]),
+                        All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::ClingGem(2)),
                     ]),
                 ]),
-                L::PEntryTheatre.into(),
+                Loc(L::PEntryTheatre),
             ]),
             L::OtherTheatrePath => Any(&[
                 All(&[
-                    Any(&[L::ThKeepEntry.into(), L::ThDungeonEntry.into()]),
+                    Any(&[Loc(L::ThKeepEntry), Loc(L::ThDungeonEntry)]),
                     Any(&[
-                        A::ClingGem(2).into(),
+                        Powerup(A::ClingGem(2)),
                         All(&[
-                            A::AscendantLight.into(),
-                            A::DreamBreaker.into(),
+                            Powerup(A::AscendantLight),
+                            Powerup(A::DreamBreaker),
                         ]),
                     ]),
                 ]),
-                All(&[L::ThKeepEntry.into(), A::HeliacalPower.into()]),
+                All(&[Loc(L::ThKeepEntry), Powerup(A::HeliacalPower)]),
                 All(&[
-                    L::ThDungeonEntry.into(),
+                    Loc(L::ThDungeonEntry),
                     Any(&[
-                        A::SunGreaves.into(),
-                        All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
+                        Powerup(A::SunGreaves),
+                        All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
                     ]),
                 ]),
             ]),
             L::PillarRoom => All(&[
-                Any(&[L::ThCastleEntryPillar.into(), L::ThBaileyEntry.into()]),
+                Any(&[Loc(L::ThCastleEntryPillar), Loc(L::ThBaileyEntry)]),
                 Any(&[
-                    A::SunGreaves.into(),
-                    A::HeliacalPower.into(),
-                    A::ClingGem(2).into(),
-                    A::Sunsetter.into(),
+                    Powerup(A::SunGreaves),
+                    Powerup(A::HeliacalPower),
+                    Powerup(A::ClingGem(2)),
+                    Powerup(A::Sunsetter),
                 ]),
             ]),
             L::TheatreEntrance => Any(&[
-                L::MainTheatre.into(),
+                Loc(L::MainTheatre),
                 All(&[
-                    L::ThCastleEntryMain.into(),
+                    Loc(L::ThCastleEntryMain),
                     Any(&[
-                        A::ClingGem(2).into(),
+                        Powerup(A::ClingGem(2)),
                         All(&[
-                            A::Slide.into(),
-                            A::SolarWind.into(),
-                            A::SunGreaves.into(),
+                            Powerup(A::Slide),
+                            Powerup(A::SolarWind),
+                            Powerup(A::SunGreaves),
                         ]),
                         All(&[
-                            A::HeliacalPower.into(),
-                            A::Sunsetter.into(),
+                            Powerup(A::HeliacalPower),
+                            Powerup(A::Sunsetter),
                         ]),
                     ]),
                 ]),
             ]),
             L::MainTheatre => Any(&[
                 All(&[
-                    L::TheatreEntrance.into(),
+                    Loc(L::TheatreEntrance),
                     Any(&[
-                        A::ClingGem(2).into(),
-                        A::SunGreaves.into(),
-                        All(&[A::Sunsetter.into(), A::HeliacalPower.into()]),
+                        Powerup(A::ClingGem(2)),
+                        Powerup(A::SunGreaves),
+                        All(&[Powerup(A::Sunsetter), Powerup(A::HeliacalPower)]),
                     ]),
                 ]),
                 All(&[
-                    L::PillarRoom.into(),
-                    A::Sunsetter.into(),
+                    Loc(L::PillarRoom),
+                    Powerup(A::Sunsetter),
                     Any(&[
-                        A::ClingGem(2).into(),
-                        All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
+                        Powerup(A::ClingGem(2)),
+                        All(&[Powerup(A::SunGreaves), Powerup(A::HeliacalPower)]),
                     ]),
                 ]),
                 All(&[
-                    L::OtherTheatrePath.into(),
-                    A::ClingGem(2).into(),
+                    Loc(L::OtherTheatrePath),
+                    Powerup(A::ClingGem(2)),
                     Any(&[
-                        A::SunGreaves.into(),
-                        A::HeliacalPower.into(),
-                        All(&[A::Slide.into(), A::SolarWind.into()]),
+                        Powerup(A::SunGreaves),
+                        Powerup(A::HeliacalPower),
+                        All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                     ]),
                 ]),
             ]),
             // Final Boss
             L::FinalBoss => Any(&[
                 All(&[
-                    L::TowerRuinsEntrance.into(),
-                    A::ClingGem(2).into(),
+                    Loc(L::TowerRuinsEntrance),
+                    Powerup(A::ClingGem(2)),
                     Any(&[
-                        A::SunGreaves.into(),
+                        Powerup(A::SunGreaves),
                         All(&[
-                            A::HeliacalPower.into(),
-                            A::Sunsetter.into(),
+                            Powerup(A::HeliacalPower),
+                            Powerup(A::Sunsetter),
                         ]),
                     ]),
                 ]),

--- a/src/logic/seeding.rs
+++ b/src/logic/seeding.rs
@@ -1,6 +1,8 @@
 use super::*;
 use strum::{EnumCount, IntoEnumIterator};
 
+use Lock::{All, Any, Movement as Powerup, Location as Loc};
+
 fn accessible(
     locks: &Lock,
     locations: &[Location],
@@ -248,11 +250,11 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 1548,
                 drop: Drop::Ability(A::HeliacalPower),
                 locks: Any(&[
-                    All(&[A::Slide.into(), A::SunGreaves.into()]),
-                    All(&[A::Slide.into(), A::HeliacalPower.into()]),
-                    All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
-                    A::ClingGem(2).into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    All(&[Powerup(A::Slide),Powerup( A::SunGreaves)]),
+                    All(&[Powerup(A::Slide),Powerup( A::HeliacalPower)]),
+                    All(&[Powerup(A::SunGreaves),Powerup( A::HeliacalPower)]),
+                    Powerup(A::ClingGem(2)),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             },
             Check {
@@ -261,11 +263,11 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 1554,
                 drop: Drop::Ability(A::HeliacalPower),
                 locks: Any(&[
-                    All(&[A::Slide.into(), A::SunGreaves.into()]),
-                    All(&[A::Slide.into(), A::HeliacalPower.into()]),
-                    All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
-                    A::ClingGem(2).into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    All(&[Powerup(A::Slide),Powerup( A::SunGreaves)]),
+                    All(&[Powerup(A::Slide),Powerup( A::HeliacalPower)]),
+                    All(&[Powerup(A::SunGreaves),Powerup( A::HeliacalPower)]),
+                    Powerup(A::ClingGem(2)),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             },
             Check {
@@ -274,11 +276,11 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 1560,
                 drop: Drop::Ability(A::HeliacalPower),
                 locks: Any(&[
-                    All(&[A::Slide.into(), A::SunGreaves.into()]),
-                    All(&[A::Slide.into(), A::HeliacalPower.into()]),
-                    All(&[A::SunGreaves.into(), A::HeliacalPower.into()]),
-                    A::ClingGem(2).into(),
-                    All(&[A::Slide.into(), A::SolarWind.into()]),
+                    All(&[Powerup(A::Slide),Powerup( A::SunGreaves)]),
+                    All(&[Powerup(A::Slide),Powerup( A::HeliacalPower)]),
+                    All(&[Powerup(A::SunGreaves),Powerup( A::HeliacalPower)]),
+                    Powerup(A::ClingGem(2)),
+                    All(&[Powerup(A::Slide), Powerup(A::SolarWind)]),
                 ]),
             },
         ]);
@@ -299,9 +301,9 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 671,
                 drop: Drop::Ability(A::ClingGem(2)),
                 locks: Any(&[
-                    A::ClingGem(2).into(),
-                    A::SunGreaves.into(),
-                    All(&[A::HeliacalPower.into(), A::Sunsetter.into()]),
+                    Powerup( A::ClingGem(2)),
+                    Powerup( A::SunGreaves),
+                    All(&[Powerup( A::HeliacalPower),Powerup(A::Sunsetter)]),
                 ]),
             },
             Check {
@@ -310,9 +312,9 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 677,
                 drop: Drop::Ability(A::ClingGem(2)),
                 locks: Any(&[
-                    A::ClingGem(2).into(),
-                    A::SunGreaves.into(),
-                    All(&[A::HeliacalPower.into(), A::Sunsetter.into()]),
+                    Powerup( A::ClingGem(2)),
+                    Powerup( A::SunGreaves),
+                    All(&[Powerup( A::HeliacalPower),Powerup(A::Sunsetter)]),
                 ]),
             },
             Check {
@@ -321,9 +323,9 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
                 index: 683,
                 drop: Drop::Ability(A::ClingGem(2)),
                 locks: Any(&[
-                    A::ClingGem(2).into(),
-                    A::SunGreaves.into(),
-                    All(&[A::HeliacalPower.into(), A::Sunsetter.into()]),
+                    Powerup( A::ClingGem(2)),
+                    Powerup( A::SunGreaves),
+                    All(&[Powerup( A::HeliacalPower),Powerup(A::Sunsetter)]),
                 ]),
             },
         ]);

--- a/src/logic/seeding.rs
+++ b/src/logic/seeding.rs
@@ -242,7 +242,6 @@ pub fn randomise(app: &crate::Rando) -> Result<(), String> {
             pool.remove(i);
         }
         use Ability as A;
-        use Lock::{All, Any};
         pool.extend([
             Check {
                 description: "where sun greaves normally is",


### PR DESCRIPTION
To get it working i went ahead and just changed all Ability .into()'s into using the Movement Lock as Powerup instead so DB looks like Powerup(A::DreamBreaker) instead but it does work. Location locks have a nice short had as Loc now