### PR TITLE
Initial Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 Cargo.lock
 spoiler_log.txt
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,17 @@ edition = "2021"
 eframe = { version = "0.26", default-features = false, features = ["default_fonts", "glow", "persistence"] }
 unreal_asset = { git = "https://github.com/astrotechies/unrealmodding", rev = "b64d3f4" }
 repak = { git = "https://github.com/trumank/repak", rev = "96410d6", features = ["oodle_explicit"] }
-oodle_loader = { git = "https://github.com/trumank/repak", rev = "96410d6" }
 strum = { version = "0.25", features = ["derive"] }
 rand = "0.8"
 egui-modal = "0.3"
 rfd = "0.11"
 thiserror = "1.0"
+
+[target.'cfg(unix)'.dependencies]
+lzma-rs = "0.3.0"
+object = { version = "0.32.1", default-features = false, features = ["std", "read"] }
+libc = "0.2.148"
+seq-macro = "0.3.5"
 
 [build-dependencies]
 winres = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 [dependencies]
 eframe = { version = "0.26", default-features = false, features = ["default_fonts", "glow", "persistence"] }
 unreal_asset = { git = "https://github.com/astrotechies/unrealmodding", rev = "b64d3f4" }
-repak = { git = "https://github.com/trumank/repak", rev = "abda6da", features = ["oodle"] }
+repak = { git = "https://github.com/trumank/repak", rev = "96410d6", features = ["oodle_explicit"] }
+oodle_loader = { git = "https://github.com/trumank/repak", rev = "96410d6" }
 strum = { version = "0.25", features = ["derive"] }
 rand = "0.8"
 egui-modal = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,17 @@
 fn main() {
     #[cfg(target_os = "windows")]
-    winres::WindowsResource::new()
-        .set_icon("src/assets/sybil.ico")
-        .compile()
-        .expect("failed to change icon");
+    {
+        winres::WindowsResource::new()
+            .set_icon("src/assets/sybil.ico")
+            .compile()
+            .expect("failed to change icon");
+
+        println!("cargo:rerun-if-env-changed=OODLE");
+        println!(
+        "cargo:rustc-link-search={}",
+        std::env::var("OODLE").unwrap_or(
+            "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string()
+        )
+    );
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,7 @@
 fn main() {
+    #[cfg(target_os = "windows")]
     winres::WindowsResource::new()
         .set_icon("src/assets/sybil.ico")
         .compile()
         .expect("failed to change icon");
-    println!("cargo:rerun-if-env-changed=OODLE");
-    println!(
-        "cargo:rustc-link-search={}",
-        std::env::var("OODLE").unwrap_or(
-            "C:/Program Files/Epic Games/UE_5.1/Engine/Source/Runtime/OodleDataCompression/Sdks/2.9.8/lib/Win64".to_string()
-        )
-    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod io;
 mod logic;
 mod map;
 mod writing;
+mod oodle;
 
 type Asset<T> = unreal_asset::Asset<std::io::Cursor<T>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn ask_game_path() -> Option<std::path::PathBuf> {
         .pick_folder()?;
     path.join("pseudoregalia/Content/Paks")
         .exists()
-        .then(|| path.join("pseudoregalia\\Content\\Paks"))
+        .then(|| path.join("pseudoregalia/Content/Paks"))
 }
 
 fn get_pak_str(pak: &std::path::Path) -> String {

--- a/src/oodle.rs
+++ b/src/oodle.rs
@@ -1,0 +1,331 @@
+// OOdle code adapted from https://github.com/trumank/repak/tree/96410d664ac46c87cf451a3c5bad38d8cf42dda5/oodle_loader
+// under the MIT License
+// Copyright 2024 Truman Kilen, spuds
+
+
+use std::sync::OnceLock;
+
+type OodleDecompress = fn(comp_buf: &[u8], raw_buf: &mut [u8]) -> i32;
+
+#[allow(non_camel_case_types)]
+type OodleLZ_Decompress = unsafe extern "win64" fn(
+    compBuf: *const u8,
+    compBufSize: usize,
+    rawBuf: *mut u8,
+    rawLen: usize,
+    fuzzSafe: u32,
+    checkCRC: u32,
+    verbosity: u32,
+    decBufBase: u64,
+    decBufSize: usize,
+    fpCallback: u64,
+    callbackUserData: u64,
+    decoderMemory: *mut u8,
+    decoderMemorySize: usize,
+    threadPhase: u32,
+) -> i32;
+
+pub fn decompress() -> Result<OodleDecompress, Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    return Ok(linux_oodle::oodle_loader_linux());
+}
+
+fn call_decompress(comp_buf: &[u8], raw_buf: &mut [u8], decompress: OodleLZ_Decompress) -> i32 {
+    unsafe {
+        decompress(
+            comp_buf.as_ptr(),
+            comp_buf.len(),
+            raw_buf.as_mut_ptr(),
+            raw_buf.len(),
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            std::ptr::null_mut(),
+            0,
+            3,
+        )
+    }
+}
+
+#[cfg(unix)]
+mod linux_oodle {
+    use super::*;
+
+    use object::pe::{
+        ImageNtHeaders64, IMAGE_REL_BASED_DIR64, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ,
+        IMAGE_SCN_MEM_WRITE,
+    };
+    use object::read::pe::{ImageOptionalHeader, ImageThunkData, PeFile64};
+
+    use object::{LittleEndian as LE, Object, ObjectSection};
+    use std::collections::HashMap;
+    use std::ffi::{c_void, CStr};
+
+    #[repr(C)]
+    struct ThreadInformationBlock {
+        exception_list: *const c_void,
+        stack_base: *const c_void,
+        stack_limit: *const c_void,
+        sub_system_tib: *const c_void,
+        fiber_data: *const c_void,
+        arbitrary_user_pointer: *const c_void,
+        teb: *const c_void,
+    }
+
+    const TIB: ThreadInformationBlock = ThreadInformationBlock {
+        exception_list: std::ptr::null(),
+        stack_base: std::ptr::null(),
+        stack_limit: std::ptr::null(),
+        sub_system_tib: std::ptr::null(),
+        fiber_data: std::ptr::null(),
+        arbitrary_user_pointer: std::ptr::null(),
+        teb: std::ptr::null(),
+    };
+
+    static DECOMPRESS: OnceLock<OodleLZ_Decompress> = OnceLock::new();
+
+    fn decompress_wrapper(comp_buf: &[u8], raw_buf: &mut [u8]) -> i32 {
+        unsafe {
+            // Set GS register in calling thread
+            const ARCH_SET_GS: i32 = 0x1001;
+            libc::syscall(libc::SYS_arch_prctl, ARCH_SET_GS, &TIB);
+
+            // Call actual decompress function
+            call_decompress(comp_buf, raw_buf, *DECOMPRESS.get().unwrap())
+        }
+    }
+
+    #[allow(non_snake_case)]
+    mod imports {
+        use super::*;
+
+        pub unsafe extern "win64" fn OutputDebugStringA(string: *const std::ffi::c_char) {
+            print!("[OODLE] {}", CStr::from_ptr(string).to_string_lossy());
+        }
+        pub unsafe extern "win64" fn GetProcessHeap() -> *const c_void {
+            0x12345678 as *const c_void
+        }
+        pub unsafe extern "win64" fn HeapAlloc(
+            _heap: *const c_void,
+            flags: i32,
+            size: usize,
+        ) -> *const c_void {
+            assert_eq!(0, flags);
+            libc::malloc(size)
+        }
+        pub unsafe extern "win64" fn HeapFree(
+            _heap: *const c_void,
+            _flags: i32,
+            ptr: *mut c_void,
+        ) -> bool {
+            libc::free(ptr);
+            true
+        }
+        pub unsafe extern "win64" fn memset(
+            ptr: *mut c_void,
+            value: i32,
+            num: usize,
+        ) -> *const c_void {
+            libc::memset(ptr, value, num)
+        }
+        pub unsafe extern "win64" fn memmove(
+            destination: *mut c_void,
+            source: *const c_void,
+            num: usize,
+        ) -> *const c_void {
+            libc::memmove(destination, source, num)
+        }
+        pub unsafe extern "win64" fn memcpy(
+            destination: *mut c_void,
+            source: *const c_void,
+            num: usize,
+        ) -> *const c_void {
+            libc::memcpy(destination, source, num)
+        }
+    }
+
+    // Create some unique function pointers to use for unimplemented imports
+    const DEBUG_FNS: [*const fn(); 100] = gen_debug_fns();
+    static mut DEBUG_NAMES: [&str; 100] = [""; 100];
+    const fn gen_debug_fns() -> [*const fn(); 100] {
+        fn log<const I: usize>() {
+            unimplemented!("import {:?}", unsafe { DEBUG_NAMES[I] });
+        }
+        let mut array = [std::ptr::null(); 100];
+        seq_macro::seq!(N in 0..100 {
+            array[N] = log::<N> as *const fn();
+        });
+        array
+    }
+
+    pub fn oodle_loader_linux() -> OodleDecompress {
+        DECOMPRESS.get_or_init(|| get_decompress_inner().unwrap());
+        decompress_wrapper
+    }
+
+    fn get_decompress_inner() -> Result<OodleLZ_Decompress, crate::writing::Error> {
+        let dll = include_bytes!("../oo2core_9_win64.dll");
+
+        let obj_file = PeFile64::parse(&dll[..])?;
+
+        let size = obj_file.nt_headers().optional_header.size_of_image() as usize;
+        let header_size = obj_file.nt_headers().optional_header.size_of_headers() as usize;
+
+        let image_base = obj_file.relative_address_base() as usize;
+
+        // Create map
+        let mmap = unsafe {
+            std::slice::from_raw_parts_mut(
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    size,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                ) as *mut u8,
+                size,
+            )
+        };
+
+        let map_base = mmap.as_ptr();
+
+        // Copy header to map
+        mmap[0..header_size].copy_from_slice(&dll[0..header_size]);
+        unsafe {
+            assert_eq!(
+                0,
+                libc::mprotect(
+                    mmap.as_mut_ptr() as *mut c_void,
+                    header_size,
+                    libc::PROT_READ
+                )
+            );
+        }
+
+        // Copy section data to map
+        for section in obj_file.sections() {
+            let address = section.address() as usize;
+            let data = section.data()?;
+            mmap[(address - image_base)..(address - image_base + data.len())]
+                .copy_from_slice(section.data()?);
+        }
+
+        // Apply relocations
+        let sections = obj_file.section_table();
+        let mut blocks = obj_file
+            .data_directories()
+            .relocation_blocks(&dll[..], &sections)?
+            .unwrap();
+
+        while let Some(block) = blocks.next()? {
+            let block_address = block.virtual_address();
+            let block_data = sections.pe_data_at(&dll[..], block_address).map(object::Bytes);
+            for reloc in block {
+                let offset = (reloc.virtual_address - block_address) as usize;
+                match reloc.typ {
+                    IMAGE_REL_BASED_DIR64 => {
+                        let addend = block_data
+                            .and_then(|data| data.read_at::<object::U64Bytes<LE>>(offset).ok())
+                            .map(|addend| addend.get(LE));
+                        if let Some(addend) = addend {
+                            mmap[reloc.virtual_address as usize
+                                ..reloc.virtual_address as usize + 8]
+                                .copy_from_slice(&u64::to_le_bytes(
+                                    addend - image_base as u64 + map_base as u64,
+                                ));
+                        }
+                    }
+                    _ => unimplemented!(),
+                }
+            }
+        }
+
+        // Fix up imports
+        let import_table = obj_file.import_table()?.unwrap();
+        let mut import_descs = import_table.descriptors()?;
+
+        let mut i = 0;
+        while let Some(import_desc) = import_descs.next()? {
+            let mut thunks = import_table.thunks(import_desc.original_first_thunk.get(LE))?;
+
+            let mut address = import_desc.first_thunk.get(LE) as usize;
+            while let Some(thunk) = thunks.next::<ImageNtHeaders64>()? {
+                let (_hint, name) = import_table.hint_name(thunk.address())?;
+                let name = String::from_utf8_lossy(name).to_string();
+
+                use imports::*;
+
+                let fn_addr = match name.as_str() {
+                    "OutputDebugStringA" => OutputDebugStringA as usize,
+                    "GetProcessHeap" => GetProcessHeap as usize,
+                    "HeapAlloc" => HeapAlloc as usize,
+                    "HeapFree" => HeapFree as usize,
+                    "memset" => memset as usize,
+                    "memcpy" => memcpy as usize,
+                    "memmove" => memmove as usize,
+                    _ => {
+                        unsafe { DEBUG_NAMES[i] = name.leak() }
+                        let a = DEBUG_FNS[i] as usize;
+                        i += 1;
+                        a
+                    }
+                };
+
+                mmap[address..address + 8].copy_from_slice(&usize::to_le_bytes(fn_addr));
+
+                address += 8;
+            }
+        }
+
+        // Build export table
+        let mut exports = HashMap::new();
+        for export in obj_file.exports()? {
+            let name = String::from_utf8_lossy(export.name());
+            let address = export.address() - image_base as u64 + map_base as u64;
+            exports.insert(name, address as *const c_void);
+        }
+
+        // Fix section permissions
+        for section in obj_file.sections() {
+            let address = section.address() as usize;
+            let data = section.data()?;
+            let size = data.len();
+
+            let mut permissions = 0;
+
+            let flags = match section.flags() {
+                object::SectionFlags::Coff { characteristics } => characteristics,
+                _ => unreachable!(),
+            };
+
+            if 0 != flags & IMAGE_SCN_MEM_READ {
+                permissions |= libc::PROT_READ;
+            }
+            if 0 != flags & IMAGE_SCN_MEM_WRITE {
+                permissions |= libc::PROT_WRITE;
+            }
+            if 0 != flags & IMAGE_SCN_MEM_EXECUTE {
+                permissions |= libc::PROT_EXEC;
+            }
+
+            unsafe {
+                assert_eq!(
+                    0,
+                    libc::mprotect(
+                        mmap.as_mut_ptr().add(address - image_base) as *mut c_void,
+                        size,
+                        permissions
+                    )
+                );
+            }
+        }
+
+        // Break things!
+        Ok(unsafe { std::mem::transmute(exports["OodleLZ_Decompress"]) })
+    }
+}

--- a/src/writing.rs
+++ b/src/writing.rs
@@ -1,5 +1,6 @@
 use super::logic::*;
 use crate::{io::*, map::*};
+use oodle_loader::decompress;
 use unreal_asset::{exports::*, properties::*};
 
 mod overworld;
@@ -55,24 +56,7 @@ pub fn write(
     let mut sync = app.pak()?;
     let pak = repak::PakBuilder::new()
         .oodle(|| {
-            Ok(|comp_buf, raw_buf| unsafe {
-                OodleLZ_Decompress(
-                    comp_buf.as_ptr(),
-                    comp_buf.len(),
-                    raw_buf.as_mut_ptr(),
-                    raw_buf.len(),
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    std::ptr::null_mut(),
-                    0,
-                    3,
-                )
-            })
+            Ok(decompress()?)
         })
         .reader_with_version(&mut sync, repak::Version::V11)?;
     let mut mod_pak = repak::PakBuilder::new()
@@ -214,24 +198,4 @@ pub fn write(
     }
     mod_pak.write_index()?;
     Ok(())
-}
-
-#[link(name = "oo2core_win64", kind = "static")]
-extern "C" {
-    fn OodleLZ_Decompress(
-        compBuf: *const u8,
-        compBufSize: usize,
-        rawBuf: *mut u8,
-        rawLen: usize,
-        fuzzSafe: u32,
-        checkCRC: u32,
-        verbosity: u32,
-        decBufBase: u64,
-        decBufSize: usize,
-        fpCallback: u64,
-        callbackUserData: u64,
-        decoderMemory: *mut u8,
-        decoderMemorySize: usize,
-        threadPhase: u32,
-    ) -> i32;
 }


### PR DESCRIPTION
Works as far as creating a seed, creating the .pak, and playing the randomized seed (see screenshot).

There are some buttons that call explorer.exe that won't work yet, neither will launching the game from within rando. I think there's an xdg-open crate that could handle that.

I replaced the simple static linked oodle library with the implementation by the repak crate (a different part of which was already in use). Note that it seems to download the library at runtime (from Warframe's servers..?), which I think is kind of suboptimal. However, it does manage to wrangle it into working on Linux at least.

![20240302224324_1](https://github.com/pseudoregalia-modding/rando/assets/20385973/f6dfc500-4e19-4eb7-a37a-c1b7d098a0f6)
